### PR TITLE
Fixing the hyperlink for the logo.

### DIFF
--- a/_includes/masthead
+++ b/_includes/masthead
@@ -3,7 +3,7 @@
 <div id="masthead-no-image-header">
 	<div class="row">
 		<div class="small-12 columns">
-			<a id="logo" href="{{ site.url }}/" title="{{ site.title }} – {{ site.slogan }}">
+			<a id="logo" href="/" title="{{ site.title }} – {{ site.slogan }}">
 				<img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ site.logo }}" width="600" height="80" alt="{{ site.title }} – {{ site.slogan }}">
 
 			</a>

--- a/_includes/masthead
+++ b/_includes/masthead
@@ -3,7 +3,7 @@
 <div id="masthead-no-image-header">
 	<div class="row">
 		<div class="small-12 columns">
-			<a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
+			<a id="logo" href="{{ site.url }}/" title="{{ site.title }} – {{ site.slogan }}">
 				<img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ site.logo }}" width="600" height="80" alt="{{ site.title }} – {{ site.slogan }}">
 
 			</a>


### PR DESCRIPTION
Tiny fix, without this clicking on the logo from a page other than the home page does not go anywhere. This fix makes the logo hyperlink to the home page.