### PR TITLE
Name change Geraint talk

### DIFF
--- a/_schedule/talks/geraint.md
+++ b/_schedule/talks/geraint.md
@@ -1,21 +1,21 @@
 ---
 layout: talk
 date: 2016-01-26 10:30:00
-title: "ASQ Simulates Queues"
+title: "Ciw - The Queueing Network Simulation"
 speaker: Geraint Palmer
 location: Room 01
 day: Tuesday
 duration: 30 minutes
 ---
 
-This talk will give the story of ASQ (ASQ Simulates Queues), an open queueing
+This talk will give the story of Ciw, an open queueing
 network simulation library.
 
 From its origins as a bit of code that verified basic queueing theory, to a developing simulation
 framework library that is being used in real projects. Working on this code has taught me a lot
 about coding, development, testing and documentation.
 
-Currently ASQ is being used in two academic projects: A study into deadlock in
+Currently Ciw is being used in two academic projects: A study into deadlock in
 queueing networks which explores analytical models of theoretical networks that
 deadlock, and the modelling of real world outpatient clinics to assess system
 demand.


### PR DESCRIPTION
Had to rename the library... so had to rename the talk. sorry.